### PR TITLE
feat(frontend): add frontend agent team skills folder structure

### DIFF
--- a/frontend/frontend-agent-orchestrator/SKILL.md
+++ b/frontend/frontend-agent-orchestrator/SKILL.md
@@ -19,7 +19,7 @@ This agent never writes production code itself — it reasons, routes, and revie
 **Triggers on**: invoked by `frontend-agent-team`, or "plan this feature",
 "break down this ticket", "orchestrate this task"
 **Input**: ticket + design reference + repo path + standards doc location
-**Output**: Plan payload (see `../frontend-agent-team/references/payload-schema.md`)
+**Output**: Plan payload (see `../references/payload-schema.md`)
 
 ---
 
@@ -79,7 +79,7 @@ Map ticket requirements onto the design:
 ### STEP 4 — Build the plan payload
 
 Produce the full plan payload as defined in
-`../frontend-agent-team/references/payload-schema.md` → section 1.
+`../references/payload-schema.md` → section 1.
 
 Rules for a good plan:
 - One component per `components_to_build` entry. Never bundle two components.
@@ -141,7 +141,7 @@ If any BLOCK findings:
 ### STEP 8 — Produce final summary
 
 Follow the final summary format defined in
-`../frontend-agent-team/SKILL.md` → STEP 4.
+`../skill (51).md` → STEP 4.
 
 Include:
 - One-paragraph narrative of what was built

--- a/frontend/frontend-agent-orchestrator/SKILL.md
+++ b/frontend/frontend-agent-orchestrator/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: frontend-agent-orchestrator
+description: >
+  Planning and coordination agent for the frontend agent team. Reads a ticket +
+  Figma design, loads local repo standards, produces a structured implementation
+  plan, delegates to the coder sub-agent, routes outputs to both verifiers, and
+  synthesizes a final summary. Trigger when an orchestrator planning phase is
+  needed inside the frontend-agent-team pipeline, or when the user says "plan
+  this feature", "break down this ticket into a frontend implementation plan",
+  or "orchestrate this frontend task". Always loads local standards before
+  generating any plan output.
+---
+
+# Frontend Agent Orchestrator
+
+Plans the implementation, delegates work, and synthesizes results.
+This agent never writes production code itself — it reasons, routes, and reviews.
+
+**Triggers on**: invoked by `frontend-agent-team`, or "plan this feature",
+"break down this ticket", "orchestrate this task"
+**Input**: ticket + design reference + repo path + standards doc location
+**Output**: Plan payload (see `../frontend-agent-team/references/payload-schema.md`)
+
+---
+
+## Step-by-step workflow
+
+### STEP 1 — Load repo standards
+
+Read the standards doc in this priority order:
+1. `STANDARDS.md` (repo root)
+2. `CONTRIBUTING.md`
+3. `.github/CONTRIBUTING.md`
+4. `docs/conventions.md`
+5. If none found: read `eslint.config.*` + `tsconfig.json` + one sample
+   component file to infer conventions. Summarize inferred conventions
+   for the user and ask for confirmation before proceeding.
+
+Extract and store:
+- **Naming**: component naming, file naming, hook naming, event handler naming
+- **Imports**: absolute vs relative, path aliases (`@/`, `~/`), barrel index rules
+- **State management**: Redux Toolkit vs Zustand vs Context, slice patterns, selector patterns
+- **Testing**: framework (Vitest/Jest), library (RTL), co-location rules, coverage expectations
+- **Folder structure**: where new components, hooks, types, and tests go
+- **TypeScript strictness**: no-any policy, explicit return types, interface vs type
+
+---
+
+### STEP 2 — Parse the design input
+
+If Figma URL provided:
+- Use Figma MCP (`framelink` or equivalent) to extract:
+  - Component names and hierarchy from the frame
+  - Design tokens: colors, spacing, font sizes, border radii
+  - Node IDs for each component (for the coder to reference)
+- Confirm extracted component list with the user if more than 5 components
+
+If image provided (screenshot or export):
+- Identify components visually: containers, typography, interactive elements
+- Note spacing estimates (approximate rem values)
+- Flag that pixel-perfect fidelity will need manual review (visual verifier will handle)
+
+---
+
+### STEP 3 — Decompose the ticket
+
+Parse the ticket for:
+- Feature description (what it does)
+- Acceptance criteria (what "done" looks like)
+- Affected areas (new page, new component, existing component change, new Redux slice)
+
+Map ticket requirements onto the design:
+- Match each acceptance criterion to one or more components
+- Identify data shapes (what does the Redux state need to look like?)
+- Identify API calls (what endpoints does this feature consume?)
+
+---
+
+### STEP 4 — Build the plan payload
+
+Produce the full plan payload as defined in
+`../frontend-agent-team/references/payload-schema.md` → section 1.
+
+Rules for a good plan:
+- One component per `components_to_build` entry. Never bundle two components.
+- `path` must follow the repo's folder structure exactly.
+- `redux_slices` only if this feature genuinely adds/modifies state.
+- `standards_summary` must be drawn from STEP 1 — never generic defaults.
+- `figma_design_tokens` populated only when Figma MCP was used.
+- If on a fix cycle, `fix_instructions` must include the exact BLOCK findings
+  from the verifier reports, translated into actionable coder instructions.
+
+---
+
+### STEP 5 — Delegate to coder
+
+Hand the plan payload to the **`frontend-coder-agent`** skill.
+
+Communicate clearly:
+- "Here is the plan payload. Implement all components_to_build in order.
+  Follow standards_summary strictly. Report back with the code report payload."
+
+Wait for the code report before continuing.
+
+---
+
+### STEP 6 — Route to verifiers
+
+On receiving the code report from the coder:
+
+1. Summarize files created/modified for the verifiers
+2. Invoke **`frontend-logic-verifier`** with: code report + plan payload + files
+3. Invoke **`frontend-visual-verifier`** with: code report + plan payload + dev server URL
+4. Both verifiers can run in parallel if subagents are available
+
+---
+
+### STEP 7 — Evaluate and loop or finalize
+
+Receive both verifier reports.
+
+If both `verdict == "PASS"` or `"PARTIAL"` with no BLOCK findings:
+→ Proceed to STEP 8 (summary)
+
+If any BLOCK findings:
+→ Check `fix_cycle` counter
+→ If `< 2`: build fix delegation payload (schema section 5), return to STEP 5
+→ If `>= 2`: stop and report to the human:
+  ```
+  ## Fix limit reached
+
+  After 2 fix cycles, the following issues remain unresolved:
+  [list BLOCK findings with file + line + message]
+
+  Recommended next steps:
+  [specific suggestions per finding]
+  ```
+
+---
+
+### STEP 8 — Produce final summary
+
+Follow the final summary format defined in
+`../frontend-agent-team/SKILL.md` → STEP 4.
+
+Include:
+- One-paragraph narrative of what was built
+- Complete file manifest
+- Verified acceptance criteria checklist
+- Any deviations from the original plan (with reasons)
+- PR title + body (conventional commits format: `feat(scope): description`)

--- a/frontend/frontend-coder-agent/SKILL.md
+++ b/frontend/frontend-coder-agent/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: frontend-coder-agent
+description: >
+  Implementation sub-agent for the frontend agent team. Receives a structured
+  plan payload from the orchestrator and writes production-quality React,
+  TypeScript, and Redux Toolkit code that strictly follows local repo standards.
+  Uses Figma MCP (Framelink) when design tokens are available, falls back to
+  image analysis. Trigger when invoked by frontend-agent-orchestrator, or when
+  the user says "implement this plan", "write the code for this component",
+  "code up this feature following these standards", or "build this from the
+  Figma design". Never starts writing without a plan payload or explicit
+  component specification.
+---
+
+# Frontend Coder Sub-Agent
+
+Turns a structured plan into working React/TypeScript/Redux code.
+Follows local repo standards exactly. Reports back a code report payload.
+
+**Triggers on**: invoked by `frontend-agent-orchestrator`, or "implement this plan",
+"write the code for this component", "build from Figma"
+**Input**: Plan payload (schema section 1)
+**Output**: Code report payload (schema section 2)
+
+---
+
+## Step-by-step workflow
+
+### STEP 1 — Ingest the plan
+
+Parse the plan payload. Before writing a single line of code:
+- Confirm `standards_summary` is present. If not, ask orchestrator to re-send.
+- Note `fix_instructions` if this is a fix cycle — these override everything else.
+- List the `components_to_build` in order. Build them sequentially.
+
+---
+
+### STEP 2 — Set up the implementation environment
+
+Check what exists at the `path` for each component:
+- If file already exists: treat as a modification (preserve existing API surface
+  unless the plan explicitly changes it)
+- If new file: follow repo folder structure from `standards_summary`
+
+For each new file, confirm the import alias works:
+- If repo uses `@/`: all imports use `@/components/...`, `@/store/...` etc.
+- Never use deep relative paths (`../../../`) unless the standards doc allows it
+
+---
+
+### STEP 3 — Extract design intent
+
+If `figma_node_id` is present for a component:
+- Use Figma MCP to fetch the node: spacing values, color tokens, font styles
+- Map Figma color names → CSS custom properties or Tailwind classes per the repo
+- Map Figma spacing → rem values or Tailwind spacing scale
+- Do NOT hardcode hex values. Use the repo's token system.
+
+If only an image was provided (no Figma node):
+- Estimate spacing visually (prefer multiples of 4px → rem)
+- Use the repo's existing color variables — do not invent new ones
+- Flag in `known_deviations` that pixel-perfect verification is required
+
+---
+
+### STEP 4 — Implement components
+
+For each component in `components_to_build`:
+
+#### 4a. Types first
+Define the props interface before the component:
+```ts
+// Follow standards_summary.naming for interface vs type
+interface ComponentNameProps {
+  // explicit types — no `any`
+}
+```
+
+#### 4b. Component file
+- Functional component, explicit return type
+- Named export (unless standards say default)
+- Props destructured at signature
+- No inline styles unless the repo pattern allows it
+- Event handlers named `handle[Event]` (unless standards differ)
+
+#### 4c. Redux slice (if plan specifies)
+- Use Redux Toolkit `createSlice`
+- State shape typed explicitly
+- Selectors co-located in the slice file (unless repo separates them)
+- No direct `dispatch` inside components — use typed hooks (`useAppDispatch`)
+
+#### 4d. Custom hooks
+- Extract data-fetching or complex state logic into hooks
+- Hook files go in `src/hooks/` or co-located per standards
+- Return typed objects (not arrays, unless single value)
+
+#### 4e. Test file
+- Create co-located test file per `standards_summary.testing`
+- Minimum: one render test, one interaction test per component
+- If RTL: use `screen.getByRole` over `getByTestId` where possible
+- If the component connects to Redux: wrap in a test store provider
+
+---
+
+### STEP 5 — Handle fix instructions
+
+If `fix_instructions` is non-null (this is a fix cycle):
+- Process BLOCK findings first, WARN findings second
+- For each finding: locate the exact file + line, apply the suggested fix
+- If the suggestion is unclear or contradicts the plan, note it in `known_deviations`
+  and apply your best judgment — do not ask the orchestrator mid-implementation
+
+---
+
+### STEP 6 — Self-review before reporting
+
+Before producing the code report, run this checklist mentally:
+
+- [ ] No TypeScript `any` (unless standards allow and it's noted)
+- [ ] All components have test files
+- [ ] Import paths follow the alias pattern
+- [ ] No hardcoded color hex values (use tokens)
+- [ ] No TODO comments left in production code
+- [ ] Redux actions are dispatched via typed hooks
+- [ ] Component props are fully typed
+- [ ] File paths match the plan exactly
+
+---
+
+### STEP 7 — Produce code report payload
+
+Return the code report payload as defined in
+`../frontend-agent-team/references/payload-schema.md` → section 2.
+
+Populate `build_status` honestly:
+- `clean`: no type errors, no lint errors
+- `warnings`: minor lint warnings that don't affect functionality
+- `errors`: type errors or lint errors that block — list them in `build_notes`
+
+Populate `known_deviations` for anything that intentionally differs from the plan.
+This is not failure — it's transparency. The orchestrator needs accurate information.

--- a/frontend/frontend-coder-agent/SKILL.md
+++ b/frontend/frontend-coder-agent/SKILL.md
@@ -130,7 +130,7 @@ Before producing the code report, run this checklist mentally:
 ### STEP 7 — Produce code report payload
 
 Return the code report payload as defined in
-`../frontend-agent-team/references/payload-schema.md` → section 2.
+`../references/payload-schema.md` → section 2.
 
 Populate `build_status` honestly:
 - `clean`: no type errors, no lint errors

--- a/frontend/frontend-logic-verifier/SKILL.md
+++ b/frontend/frontend-logic-verifier/SKILL.md
@@ -109,7 +109,7 @@ runtime bug or fail CI. False BLOCK findings waste a fix cycle.
 ### STEP 5 — Produce logic verifier report
 
 Return the report payload as defined in
-`../frontend-agent-team/references/payload-schema.md` → section 3.
+`../references/payload-schema.md` → section 3.
 
 `verdict` rules:
 - `PASS`: zero BLOCK findings (WARN/INFO may exist)

--- a/frontend/frontend-logic-verifier/SKILL.md
+++ b/frontend/frontend-logic-verifier/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: frontend-logic-verifier
+description: >
+  Code review sub-agent for the frontend agent team. Receives the coder's output
+  and verifies it against local repo standards — TypeScript strictness, naming
+  conventions, React/Redux patterns, test presence, and architecture rules.
+  Produces a structured PASS/FAIL report with BLOCK/WARN/INFO findings.
+  Trigger when invoked by frontend-agent-orchestrator, or when the user says
+  "verify this code", "check this against our standards", "logic review",
+  "code review this output", or "does this follow our conventions?". This agent
+  reviews intent and structure — not visual output (that's the visual verifier).
+---
+
+# Frontend Logic Verifier
+
+Reviews coder output for correctness, standards compliance, and pattern quality.
+Produces a structured findings report — not inline comments on the code.
+
+**Triggers on**: invoked by `frontend-agent-orchestrator`, "verify this code",
+"check against our standards", "logic review", "does this follow our conventions?"
+**Input**: Code report payload + plan payload + file contents
+**Output**: Logic verifier report (schema section 3)
+
+---
+
+## Step-by-step workflow
+
+### STEP 1 — Load review context
+
+Before reviewing any file:
+1. Read `standards_summary` from the plan payload — this is the ground truth
+2. Note `known_deviations` from the code report — these are pre-declared exceptions
+3. Note `fix_instructions` if present — verify those specific items are resolved
+
+Do not apply generic "best practice" rules that contradict the repo's standards.
+The repo's standards win, even if you personally disagree with them.
+
+---
+
+### STEP 2 — Review each file
+
+For each file in `files_created` and `files_modified`:
+
+#### TypeScript (category: `type_safety`)
+- [ ] No bare `any` — flag every occurrence
+- [ ] All props interfaces fully typed
+- [ ] Event handler types explicit (`React.ChangeEvent<HTMLInputElement>` not `any`)
+- [ ] Hook return types explicit
+- [ ] Redux state shape typed
+- [ ] Typed selectors (`RootState`)
+- [ ] `useAppDispatch` / `useAppSelector` used (not raw `useDispatch` / `useSelector`)
+
+#### Naming (category: `naming_conventions`)
+- [ ] Component names: PascalCase, match filename
+- [ ] Hook names: `use` prefix, camelCase
+- [ ] Event handlers: `handle` + EventName pattern (per standards)
+- [ ] Redux slices: `<feature>Slice` pattern (per standards)
+- [ ] Selector names: `select<Thing>` pattern (per standards)
+- [ ] Test describe blocks: match component name
+
+#### Patterns (category: `patterns`)
+- [ ] No direct store mutation outside reducers
+- [ ] No `useEffect` with missing dependencies (unless intentional — flag it)
+- [ ] No inline anonymous functions passed as stable props where memoization matters
+- [ ] No `console.log` or `debugger` left in code
+- [ ] No hardcoded strings that should be constants or i18n keys (per standards)
+- [ ] Async actions use RTK `createAsyncThunk` or equivalent per standards
+- [ ] Error states handled in components (not silently swallowed)
+
+#### Standards compliance (category: `standards_compliance`)
+- [ ] Import paths use correct alias (e.g. `@/`) per standards
+- [ ] No forbidden barrel imports if standards prohibit them
+- [ ] Folder structure matches plan + standards
+- [ ] Export style matches standards (named vs default)
+- [ ] No magic numbers — extract to named constants
+
+#### Tests (category: `tests_present`)
+- [ ] Test file exists for every new component
+- [ ] At minimum: one render test + one interaction test per component
+- [ ] Redux-connected components have test store setup
+- [ ] No `screen.getByTestId` unless `getByRole` / `getByText` is impossible
+- [ ] Tests do not import internal implementation details
+
+---
+
+### STEP 3 — Check fix cycle resolution
+
+If `fix_instructions` was non-null (this is a fix cycle):
+- For each BLOCK finding from the previous cycle: confirm it is resolved
+- If a BLOCK finding is still present: mark it as BLOCK again with note
+  "persisted from fix cycle N"
+- If the coder added a new BLOCK: include it normally
+
+---
+
+### STEP 4 — Assign severity
+
+| Severity | Meaning |
+|---|---|
+| `BLOCK` | Must fix. Bug, type error, security hole, broken standard. Will break CI or cause runtime errors. |
+| `WARN` | Should fix. Tech debt, inconsistency, future risk. Won't break CI today. |
+| `INFO` | Optional. Style suggestion, minor improvement. Take or leave. |
+
+Err on the side of `WARN` over `BLOCK` unless you are certain it will cause a
+runtime bug or fail CI. False BLOCK findings waste a fix cycle.
+
+---
+
+### STEP 5 — Produce logic verifier report
+
+Return the report payload as defined in
+`../frontend-agent-team/references/payload-schema.md` → section 3.
+
+`verdict` rules:
+- `PASS`: zero BLOCK findings (WARN/INFO may exist)
+- `FAIL`: one or more BLOCK findings
+
+For every finding, `suggestion` should be actionable — a specific fix, not
+"consider refactoring this". The coder needs to act on it without asking questions.
+
+Example finding:
+```json
+{
+  "severity": "BLOCK",
+  "file": "src/components/ProductCard/ProductCard.tsx",
+  "line": 34,
+  "rule": "no-any",
+  "message": "Props type uses `any` for onClick handler",
+  "suggestion": "Replace with `onClick: (id: string) => void`"
+}
+```

--- a/frontend/frontend-visual-verifier/SKILL.md
+++ b/frontend/frontend-visual-verifier/SKILL.md
@@ -125,7 +125,7 @@ Use FAIL only for obviously broken layouts or completely wrong designs.
 ### STEP 6 — Produce visual verifier report
 
 Return the report payload as defined in
-`../frontend-agent-team/references/payload-schema.md` → section 4.
+`../references/payload-schema.md` → section 4.
 
 For each component, `notes` should be specific:
 - Good: "Bottom padding on card is ~8px, design shows 16px. Use `pb-4` instead of `pb-2`."

--- a/frontend/frontend-visual-verifier/SKILL.md
+++ b/frontend/frontend-visual-verifier/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: frontend-visual-verifier
+description: >
+  Visual review sub-agent for the frontend agent team. Navigates a locally
+  running dev server via GitHub Copilot browser agent mode (VS Code agent mode
+  or Copilot Workspace preview) to visually inspect implemented components,
+  then compares against the Figma design or reference image. Produces a
+  structured PASS/PARTIAL/FAIL report on layout, spacing, and color fidelity.
+  Trigger when invoked by frontend-agent-orchestrator, or when the user says
+  "visually check this", "verify the UI", "does this match the design",
+  "check the local preview", "compare against Figma", or "run the browser check".
+  Falls back to static screenshot diff or manual-review flag if browser tooling
+  is unavailable.
+---
+
+# Frontend Visual Verifier
+
+Checks that the implemented UI matches the design reference.
+Uses GitHub Copilot browser agent (VS Code) to navigate localhost and screenshot.
+
+**Triggers on**: invoked by `frontend-agent-orchestrator`, "visually check this",
+"verify the UI", "compare against Figma", "check the local preview"
+**Input**: Code report payload + plan payload + dev server URL
+**Output**: Visual verifier report (schema section 4)
+
+---
+
+## Step-by-step workflow
+
+### STEP 1 — Confirm browser tooling availability
+
+Check which preview mechanism is available:
+
+**Option A — GitHub Copilot in VS Code (agent mode)**
+- Requires VS Code with GitHub Copilot extension in agent mode (`@workspace`)
+- Copilot's browser tool can navigate to `localhost` and capture screenshots
+- Available when user is running the pipeline from Claude Code or a Copilot-enabled terminal
+
+**Option B — GitHub Copilot Workspace (browser-based)**
+- Built-in preview pane available for web-based Copilot Workspace sessions
+- Use the workspace preview URL instead of localhost
+
+**Option C — No browser tooling (fallback)**
+- If neither A nor B is available, set `screenshot_taken: false`
+- Set `manual_review_needed: true` with reason "browser tooling unavailable"
+- Still perform static analysis: review the component JSX/TSX against the design
+  description for obvious structural mismatches
+- Flag specific things to manually verify (e.g. "check spacing on mobile viewport")
+
+Confirm which option is active before proceeding.
+
+---
+
+### STEP 2 — Start / confirm the dev server
+
+Before navigating, confirm the dev server is running:
+```
+Expected: http://localhost:3000 (or whatever port is in package.json scripts)
+```
+
+If not running:
+- Instruct the coder agent (or the user) to run `npm run dev` / `yarn dev`
+- Wait for "ready" signal before navigating
+- Do not time out for more than 30 seconds — if it doesn't start, fall back to Option C
+
+---
+
+### STEP 3 — Navigate to each component
+
+For each component in the plan's `components_to_build`:
+
+Determine the route to navigate to:
+- If the component is a full page: navigate to its route (from the router config)
+- If it's a sub-component: navigate to a Storybook story
+  (`http://localhost:6006` or equivalent) or the page it lives on
+- If neither: ask the user for the route/story path and record it
+
+For each component, capture:
+1. Default state (initial render)
+2. Interactive state if applicable (hover, focus, active, loading, error)
+3. Mobile viewport (375px wide) if the feature is responsive
+
+---
+
+### STEP 4 — Compare against design reference
+
+For each captured screenshot, compare against the Figma node or reference image:
+
+#### Layout
+- Overall structure matches (columns, rows, card structure)
+- Component hierarchy matches (nesting, containment)
+- Responsive behavior matches (breakpoints, stacking)
+
+#### Spacing
+- Margins and padding visually consistent with design
+- Gap between elements matches design tokens
+- Note: exact pixel matching is not required — check proportional consistency
+
+#### Color
+- Background colors match design tokens
+- Text colors match
+- Border colors match
+- Interactive state colors (hover, focus rings) match
+
+#### Typography
+- Font sizes visually consistent
+- Font weights correct (regular vs medium vs bold)
+- Line height and letter spacing roughly match
+
+---
+
+### STEP 5 — Assign verdict per component
+
+| Match level | Verdict | Meaning |
+|---|---|---|
+| All layout/spacing/color/type match | `PASS` | Ship it |
+| Minor spacing or color discrepancies | `PARTIAL` | Note it, orchestrator decides |
+| Major layout mismatch, wrong colors, missing elements | `FAIL` | Block — fix needed |
+
+PARTIAL is not failure. The orchestrator decides whether PARTIAL warrants a fix cycle.
+Use FAIL only for obviously broken layouts or completely wrong designs.
+
+---
+
+### STEP 6 — Produce visual verifier report
+
+Return the report payload as defined in
+`../frontend-agent-team/references/payload-schema.md` → section 4.
+
+For each component, `notes` should be specific:
+- Good: "Bottom padding on card is ~8px, design shows 16px. Use `pb-4` instead of `pb-2`."
+- Bad: "Spacing looks off."
+
+Set `manual_review_needed: true` if:
+- Browser tooling was unavailable (Option C)
+- Screenshots could not be captured for any reason
+- The design reference was only an image (not Figma with tokens)
+- The component requires a specific data state that couldn't be reproduced locally
+
+Always populate `preview_url` with the URL that was (or would have been) used,
+even in fallback mode. It helps the human do a quick manual check.

--- a/frontend/references/payload-schema.md
+++ b/frontend/references/payload-schema.md
@@ -1,0 +1,120 @@
+# Inter-agent payload schemas
+
+All agents communicate via structured payloads. These are the canonical shapes.
+
+---
+
+## 1. Plan payload (Orchestrator → Coder)
+
+```json
+{
+  "plan_id": "string (uuid)",
+  "ticket_summary": "string (≤3 sentences)",
+  "acceptance_criteria": ["string"],
+  "components_to_build": [
+    {
+      "name": "ComponentName",
+      "path": "src/components/path/ComponentName.tsx",
+      "description": "what it renders",
+      "props": ["prop: type"],
+      "redux_slices": ["sliceName — what it manages"],
+      "figma_node_id": "string | null"
+    }
+  ],
+  "files_to_create": ["relative/path/to/file.ts"],
+  "files_to_modify": ["relative/path/to/existing.ts"],
+  "standards_summary": {
+    "naming": "string (e.g. PascalCase components, camelCase hooks)",
+    "imports": "string (e.g. absolute paths via @/)",
+    "state_management": "string (e.g. Redux Toolkit, no direct store mutation)",
+    "testing": "string (e.g. Vitest + RTL, co-located __tests__)"
+  },
+  "figma_design_tokens": {
+    "colors": {},
+    "spacing": {},
+    "typography": {}
+  },
+  "fix_instructions": "string | null (populated on fix cycles)"
+}
+```
+
+---
+
+## 2. Code report payload (Coder → Orchestrator)
+
+```json
+{
+  "plan_id": "string",
+  "files_created": ["relative/path"],
+  "files_modified": ["relative/path"],
+  "open_questions": ["string"],
+  "known_deviations": [
+    { "file": "string", "reason": "string" }
+  ],
+  "test_files_created": ["relative/path"],
+  "build_status": "clean | warnings | errors",
+  "build_notes": "string | null"
+}
+```
+
+---
+
+## 3. Logic verifier report (LogicVerifier → Orchestrator)
+
+```json
+{
+  "plan_id": "string",
+  "verdict": "PASS | FAIL",
+  "findings": [
+    {
+      "severity": "BLOCK | WARN | INFO",
+      "file": "relative/path",
+      "line": "number | null",
+      "rule": "string (e.g. no-any, naming-convention)",
+      "message": "string",
+      "suggestion": "string | null"
+    }
+  ],
+  "categories": {
+    "type_safety": "PASS | FAIL",
+    "naming_conventions": "PASS | FAIL",
+    "patterns": "PASS | FAIL",
+    "tests_present": "PASS | FAIL",
+    "standards_compliance": "PASS | FAIL"
+  }
+}
+```
+
+---
+
+## 4. Visual verifier report (VisualVerifier → Orchestrator)
+
+```json
+{
+  "plan_id": "string",
+  "verdict": "PASS | PARTIAL | FAIL",
+  "preview_url": "string (localhost URL used)",
+  "components_checked": [
+    {
+      "name": "string",
+      "route_or_story": "string",
+      "layout_match": "PASS | PARTIAL | FAIL",
+      "spacing_match": "PASS | PARTIAL | FAIL",
+      "color_match": "PASS | PARTIAL | FAIL",
+      "notes": "string | null"
+    }
+  ],
+  "screenshot_taken": "boolean",
+  "manual_review_needed": "boolean",
+  "manual_review_reason": "string | null"
+}
+```
+
+---
+
+## 5. Fix delegation payload (Orchestrator → Coder, fix cycle)
+
+Same shape as Plan payload (#1) but with:
+- `fix_instructions` populated with BLOCK findings from both verifiers
+- `components_to_build` scoped only to failing components
+- `fix_cycle: number` added at root

--- a/frontend/references/standards-defaults.md
+++ b/frontend/references/standards-defaults.md
@@ -1,0 +1,95 @@
+# Standards defaults
+
+Used by the orchestrator when no explicit standards doc is found in the repo.
+These are Carousell-aligned React/TypeScript defaults. Always confirm with
+the user before applying these — they are fallbacks, not facts.
+
+---
+
+## Naming
+
+| Thing | Convention | Example |
+|---|---|---|
+| Components | PascalCase, matches filename | `ProductCard.tsx` |
+| Hooks | `use` prefix, camelCase | `useProductList` |
+| Event handlers | `handle` + Event | `handleSubmit`, `handleChange` |
+| Redux slices | `<feature>Slice` | `productListSlice` |
+| Selectors | `select` + Thing | `selectProductList` |
+| Types/interfaces | PascalCase, no `I` prefix | `ProductCardProps` |
+| Constants | SCREAMING_SNAKE | `MAX_RETRY_COUNT` |
+| Test files | `__tests__/ComponentName.test.tsx` | co-located |
+
+---
+
+## Imports
+
+- Absolute imports via `@/` alias pointing to `src/`
+- No deep relative paths (`../../../`) — use alias instead
+- Barrel `index.ts` allowed at component folder level
+- External libraries before internal imports (ESLint import/order)
+
+---
+
+## State management
+
+- Redux Toolkit (`createSlice`, `createAsyncThunk`)
+- Typed hooks: `useAppDispatch`, `useAppSelector` (no raw hooks)
+- Selectors co-located in slice file
+- No direct store mutation outside `extraReducers` / `reducers`
+- Server state: React Query (TanStack Query) — do not put API response cache in Redux
+
+---
+
+## TypeScript
+
+- `strict: true` — no `any` without explicit comment explaining why
+- Explicit return types on all exported functions and hooks
+- Prefer `interface` for object shapes, `type` for unions/aliases
+- No non-null assertions (`!`) unless provably safe — use optional chaining
+
+---
+
+## Folder structure
+
+```
+src/
+  components/
+    FeatureName/
+      ComponentName.tsx
+      ComponentName.module.css   (if CSS Modules used)
+      __tests__/
+        ComponentName.test.tsx
+      index.ts                   (barrel export)
+  hooks/
+    useHookName.ts
+    __tests__/
+      useHookName.test.ts
+  store/
+    slices/
+      featureSlice.ts
+    hooks.ts                     (useAppDispatch, useAppSelector)
+    index.ts
+  types/
+    feature.types.ts
+```
+
+---
+
+## Testing
+
+- Framework: Vitest
+- Library: React Testing Library
+- Prefer `screen.getByRole` > `getByText` > `getByTestId`
+- Wrap Redux-connected components in a `renderWithStore` helper
+- Minimum per component: render test + one user interaction test
+- No snapshot tests (brittle, avoid)
+
+---
+
+## Code style
+
+- No `console.log` in production code (use a logger utility)
+- No magic numbers — extract to named constants
+- No TODOs committed to main (convert to tickets)
+- Max 200 lines per component file — split if larger
+- Props spread (`{...props}`) only at the outermost element, and only if intentional

--- a/frontend/skill (51).md
+++ b/frontend/skill (51).md
@@ -1,0 +1,121 @@
+---
+name: frontend-agent-team
+description: >
+  Runs a full autonomous frontend implementation pipeline — orchestrator plans,
+  coder builds, logic verifier reviews code, visual verifier checks UI in browser,
+  then orchestrator summarizes with a PR-ready report. Trigger whenever a user says
+  "implement this ticket", "build this frontend feature", "here's a Figma + story",
+  "use the agent team", "run the frontend agents", "implement this with the full
+  pipeline", or provides a task + Figma URL/image and wants end-to-end delivery.
+  Also trigger when the user says "do the whole thing" or "handle this ticket
+  autonomously". This is the entry point for the entire multi-agent workflow.
+---
+
+# Frontend Agent Team
+
+Entry point for the full autonomous frontend implementation pipeline.
+Coordinates four sub-agents: orchestrator, coder, logic verifier, visual verifier.
+
+**Triggers on**: "implement this ticket", "run the full pipeline", "use the agent
+team", task + Figma URL combo, "do this autonomously", "handle this end to end"
+**Input**: Feature ticket / story + Figma URL or design image + local repo path
+**Output**: Implemented code, two verification reports, PR description
+
+---
+
+## Pipeline overview
+
+```
+[ticket + figma/image + repo] 
+        ↓
+  ORCHESTRATOR  — reads standards, builds plan
+        ↓  delegate
+    CODER       — implements React/TS/Redux
+        ↓  report
+  ORCHESTRATOR  — routes to both verifiers
+      ↙           ↘
+LOGIC VERIFIER   VISUAL VERIFIER
+      ↘           ↙
+  ORCHESTRATOR  — all pass? summarize : fix loop
+        ↓
+  PR SUMMARY
+```
+
+Max 2 fix cycles. On third failure → surface issues to human.
+
+---
+
+## Step-by-step workflow
+
+### STEP 1 — Gather inputs
+
+Require before starting:
+- **Ticket**: user story, acceptance criteria, or task description
+- **Design**: Figma URL (uses Figma MCP) OR attached image
+- **Repo path**: local path or assume CWD if not given
+- **Standards doc**: look for `STANDARDS.md`, `CONTRIBUTING.md`,
+  `.github/CONTRIBUTING.md`, or `docs/conventions.md` in repo root
+
+If standards doc is missing, ask the user to point to it or confirm defaults.
+Do not proceed without at least one of: standards doc, or user confirmation to
+use inferred conventions from reading the codebase.
+
+---
+
+### STEP 2 — Load the appropriate sub-agent skill
+
+Read and follow:
+
+1. **`frontend-agent-orchestrator/SKILL.md`** → executes the planning phase
+2. **`frontend-coder-agent/SKILL.md`** → executes the implementation phase
+3. **`frontend-logic-verifier/SKILL.md`** → executes code review
+4. **`frontend-visual-verifier/SKILL.md`** → executes visual review
+5. Return here to run the fix loop and final summary
+
+---
+
+### STEP 3 — Fix loop
+
+After both verifiers report:
+- If both PASS → proceed to STEP 4
+- If either FAIL:
+  - Increment `fix_cycle` counter (start at 0)
+  - If `fix_cycle < 2`: feed failure findings back to orchestrator, re-delegate
+    to coder with explicit `fix_instructions` payload, re-run both verifiers
+  - If `fix_cycle >= 2`: stop. Surface remaining failures to the human with
+    a clear summary of what needs manual resolution. Do not loop again.
+
+---
+
+### STEP 4 — Final summary
+
+Produce a PR-ready report:
+```
+## What was built
+[2–3 sentence description of the feature]
+
+## Files changed
+[list of new/modified files with one-line purpose]
+
+## Design fidelity
+[Pass / Partial / manual-review-needed — from visual verifier]
+
+## Code quality
+[Pass / issues-resolved / outstanding — from logic verifier]
+
+## Acceptance criteria
+[check each criterion from the ticket: ✅ met / ⚠️ partial / ❌ not met]
+
+## Known deviations
+[anything that differs from the plan, with reason]
+
+## PR description (copy-paste ready)
+[conventional commit style title + body]
+```
+
+---
+
+## Reference files
+
+- `references/payload-schema.md` — JSON structures passed between agents
+- `references/standards-defaults.md` — fallback conventions if no standards doc


### PR DESCRIPTION
## What this PR adds

Adds the complete `frontend/` folder with the multi-agent skill system for autonomous frontend implementation.

## Folder structure

```
frontend/
├── skill (51).md                          ← Entry point: frontend-agent-team
├── frontend-agent-orchestrator/
│   └── SKILL.md                           ← Planning phase (SKILL-52)
├── frontend-coder-agent/
│   └── SKILL.md                           ← Implementation phase (SKILL-53)
├── frontend-logic-verifier/
│   └── SKILL.md                           ← Code review (SKILL-54)
├── frontend-visual-verifier/
│   └── SKILL.md                           ← Visual review (SKILL-55)
└── references/
    ├── payload-schema.md                  ← Inter-agent JSON payload schemas
    └── standards-defaults.md             ← Fallback React/TS coding standards
```

## Agent pipeline

```
[ticket + figma + repo]
        ↓
  ORCHESTRATOR  — reads standards, builds plan
        ↓
    CODER       — implements React/TS/Redux
        ↓
  ORCHESTRATOR  — routes to both verifiers
    ↙               ↘
LOGIC VERIFIER   VISUAL VERIFIER
    ↘               ↙
  ORCHESTRATOR  — pass? summarize : fix loop (max 2)
        ↓
  PR SUMMARY
```

## Files added
- `frontend/skill (51).md` — entry point, full pipeline coordinator
- `frontend/frontend-agent-orchestrator/SKILL.md` — plan + delegate + synthesize
- `frontend/frontend-coder-agent/SKILL.md` — React/TS/Redux implementation
- `frontend/frontend-logic-verifier/SKILL.md` — standards & type safety review
- `frontend/frontend-visual-verifier/SKILL.md` — Figma/UI visual fidelity check
- `frontend/references/payload-schema.md` — all 5 inter-agent JSON payloads
- `frontend/references/standards-defaults.md` — fallback coding conventions